### PR TITLE
getDataExchangeHistohour method is not working

### DIFF
--- a/src/News.php
+++ b/src/News.php
@@ -22,7 +22,7 @@ class News extends CryptocompareApi
      * @param int $limit
      * @return mixed
      */
-    public function getDataExchangeHistohour($feeds = "cryptocompare,cryptoglobe", $categories = "Blockchain,ICO", $excludeCategories  = "", $lTs = "1507469305", $lang = "EN", $sortOrder = "latest", $sign= false, $limit = 1440) {
+    public function getDataExchangeHistohour($feeds = "cryptocompare,cryptoglobe", $categories = "Blockchain,ICO", $excludeCategories  = "NO_EXCLUDED_NEWS_CATEGORIES", $lTs = "1507469305", $lang = "EN", $sortOrder = "latest", $sign= false, $limit = 1440) {
         $extraParams = $this->appplicationName;
 
         $params = array(
@@ -36,7 +36,7 @@ class News extends CryptocompareApi
             "sortOrder" => $sortOrder,
             "sign" => $sign,
         );
-        $r = $this->getRequest("public", "/data/v2/news", $params);
+        $r = $this->getRequest("public", "/data/v2/news/", $params);
         return $r;
     }
 


### PR DESCRIPTION
1. sending request to "/data/v2/news" is giving "Path does not exist" error. updating request url from "/data/v2/news" to  "/data/v2/news/" solved problem.
2. making request  $excludeCategories = "" with  gives "excludeCategories is invalid." error. 
updating default value of  excludeCategories to  $excludeCategories = "NO_EXCLUDED_NEWS_CATEGORIES" solves problem

*** Also there is no limit parameter for this request. I forgot to remove it